### PR TITLE
chore: disable l10n synthetic package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,8 +25,9 @@ jobs:
       flutter_channel: stable
       flutter_version: 3.29.3
       test_recursion: true
-      coverage_excludes: "**/*.g.dart"
+      coverage_excludes: "**/*.g.dart lib/l10n/arb/*.dart"
       min_coverage: 75
+      format_directories: $(find . -name '*.dart' -not -name '*.g.dart' -not -name '*.gen.dart' -not -name '*.mocks.dart' -not -name '*.freezed.dart' -not -name '*.graphql.dart' -not -path './lib/l10n/arb/*' -not -path '**/.dart_tool/*')
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ app.*.map.json
 
 # configuration
 *.env
+
+# Generated localization files
+lib/l10n/arb/*.dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,4 +3,6 @@ linter:
   rules:
     public_member_api_docs: false
 analyzer:
-  exclude: ["**.g.dart"]
+  exclude:
+    - "**.g.dart"
+    - "lib/l10n/arb/*.dart"

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -2,3 +2,5 @@ arb-dir: lib/l10n/arb
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
+synthetic-package: false
+format: true

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -2,7 +2,7 @@ import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:juan_kite/app/app_routes.dart';
-import 'package:juan_kite/extensions/l10n.dart';
+import 'package:juan_kite/l10n/arb/app_localizations.dart';
 import 'package:juan_kite/theme/app_theme.dart';
 
 class App extends StatelessWidget {

--- a/lib/extensions/l10n.dart
+++ b/lib/extensions/l10n.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-
-export 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:juan_kite/l10n/arb/app_localizations.dart';
 
 extension AppLocalizationsX on BuildContext {
   AppLocalizations get l10n => AppLocalizations.of(this);

--- a/test/helpers/pump_app.dart
+++ b/test/helpers/pump_app.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:juan_kite/extensions/l10n.dart';
+import 'package:juan_kite/l10n/arb/app_localizations.dart';
 
 extension PumpApp on WidgetTester {
   Future<void> pumpApp(Widget widget) {


### PR DESCRIPTION
More info: https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source

Unfortunately the generated `l10n` files break formatting, see:
https://github.com/flutter/flutter/issues/102983#issuecomment-2707419112

Hence, the main workflow in CI has to now manually include / exclude files, as opposed to using the default values of `lib test` as before.